### PR TITLE
partial fix on edit profile

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -19,7 +19,7 @@
         <p class="username"><%= current_user.username %></p>
         <% if current_user.photo.attached? %>
           <button  class="btn-overlay" data-target="edit-container">
-            <%= cl_image_tag current_user.photo.key, :crop=>"fill" %>
+            <%= cl_image_tag current_user.photo.key, :crop=>"fill", class: "avatar overlay-toggle" %>
           </button>
         <% else %>
           <button class="btn-overlay" data-target="edit-container">
@@ -123,6 +123,14 @@
                     input_html: { autocomplete: "new-username" } %>
         <%= f.input :email, required: false, autofocus: false %>
         <%= f.input :photo, as: :file, required: false %>
+        <%= f.input :password,
+                    hint: "leave it blank if you don't want to change it",
+                    required: false,
+                    label: "Update password",
+                    input_html: { autocomplete: "new-password" } %>
+        <%= f.input :password_confirmation,
+                    required: false,
+                    input_html: { autocomplete: "new-password" } %>
         <%= f.input :current_password,
                     hint: "we need your current password to confirm your changes",
                     required: true,


### PR DESCRIPTION
You can add profile photos again, but the bugs are still there (all fields are required to edit profile, sign-up errors redirect to a non-working form)